### PR TITLE
FEATURE: Full width sidebar

### DIFF
--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -1,11 +1,11 @@
-import { default as discourseComputed, on, observes } from 'discourse-common/utils/decorators';
-import { inject as service } from "@ember/service";
 import { computed } from "@ember/object";
-import { alias, or, not, and } from "@ember/object/computed";
+import { alias, and, not, or } from "@ember/object/computed";
 import Mixin from "@ember/object/mixin";
-import { scheduleOnce, bind, later, throttle, debounce } from "@ember/runloop";
+import { bind, debounce, scheduleOnce } from "@ember/runloop";
+import { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { iconHTML } from "discourse-common/lib/icon-library";
+import { default as discourseComputed, observes, on } from 'discourse-common/utils/decorators';
 import DiscourseURL from "discourse/lib/url";
 import { normalizeContext } from "../lib/layouts";
 
@@ -163,15 +163,15 @@ export default Mixin.create({
   },
 
   handleFullSidebar() {
-    if ($('aside.sidebar.left.full')) {
-      $("#main-outlet").addClass("push-right");
-      $('.desktop-view').css('overflow-x', "hidden");
-      $('aside.sidebar.left').addClass('full-left');
-    }    
-    if ($('aside.sidebar.right.full')) {
-      // $("#main-outlet").addClass('push-left');
-      $('aside.sidebar.right').addClass('full-right');
-    }
+    // if ($('aside.sidebar.left.full')) {
+    //   $("#main-outlet").addClass("push-right");
+    //   $('.desktop-view').css('overflow-x', "hidden");
+    //   // $('aside.sidebar.left').addClass('full-left');
+    // }    
+    // if ($('aside.sidebar.right.full')) {
+    //   $("#main-outlet").addClass('push-left');
+    //   // $('aside.sidebar.right').addClass('full-right');
+    // }
   },
 
   @discourseComputed('responsiveView')
@@ -222,12 +222,18 @@ export default Mixin.create({
   
   buildSidebarClasses(isResponsive, visible, side) {
     let classes = '';
+
     if (isResponsive) {
       classes += 'is-responsive';
       if (visible) classes += ' open';
     } else {
       if (!visible) classes += ' not-visible';
     }
+    if (this.siteSettings[`layouts_sidebar_${side}_position`] === 'full') {
+      classes += ` full-${side}`;
+      $('#main-outlet').addClass('push-right'); // TODO change to not jquery
+    }
+
     classes += ` ${this.siteSettings[`layouts_sidebar_${side}_position`]}`;
     return classes;
   },

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -163,13 +163,14 @@ export default Mixin.create({
   },
 
   handleFullSidebar() {
-    if ($('aside.sidebar.left').hasClass('full')) {
-      $('#main-outlet').addClass('push-right');
+    if ($('aside.sidebar.left.full')) {
+      $("#main-outlet").addClass("push-right");
       $('.desktop-view').css('overflow-x', "hidden");
-
-    }
-    if ($('aside.sidebar.right').hasClass('full')) {
-      $('#main-outlet').addClass('push-left');
+      $('aside.sidebar.left').addClass('full-left');
+    }    
+    if ($('aside.sidebar.right.full')) {
+      // $("#main-outlet").addClass('push-left');
+      $('aside.sidebar.right').addClass('full-right');
     }
   },
 
@@ -205,7 +206,7 @@ export default Mixin.create({
       }
     }
     if (loading) classes + ' loading';
-    
+   
     return classes;
   },
 

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -252,7 +252,7 @@ export default Mixin.create({
     if (this.site.mobileView) return;
     const mainLeftOffset = this.mainLeftOffset;
     const mainRightOffset = this.mainRightOffset;
-    const sidebarLeftPosition = this.siteSettings.layouts_sidebar_left_position;
+    const leftFull = this.leftFull;
     const root = document.documentElement;
      
     let offset = 0;
@@ -263,7 +263,7 @@ export default Mixin.create({
     if (hasRightSidebar) {
       offset += mainRightOffset;
     }
-    if (hasLeftSidebar && sidebarLeftPosition === 'full') {
+    if (hasLeftSidebar && leftFull) {
       offset = 0;
       root.style.setProperty('overflow-x', 'hidden');
     }

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -253,8 +253,7 @@ export default Mixin.create({
     const mainLeftOffset = this.mainLeftOffset;
     const mainRightOffset = this.mainRightOffset;
     const leftFull = this.leftFull;
-    const root = document.documentElement;
-     
+
     let offset = 0;
     let style = '';
     if (hasLeftSidebar) {
@@ -265,11 +264,19 @@ export default Mixin.create({
     }
     if (hasLeftSidebar && leftFull) {
       offset = 0;
-      root.style.setProperty('overflow-x', 'hidden');
     }
     style += `width: ${offset > 0 ? `calc(100% - ${offset}px)` : '100%'}`;
-
     return htmlSafe(style);
+  },
+
+  @discourseComputed('hasLeftSidebar', 'hasRightSidebar')
+  rootStyle(hasLeftSidebar, hasRightSidebar) {
+    const root = document.documentElement;
+    const leftFull = this.leftFull;
+
+    if (hasLeftSidebar && leftFull) {
+      root.style.setProperty('overflow-x', 'hidden');
+    }
   },
 
   @discourseComputed('path', 'isResponsive', 'leftSidebarVisible')

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -72,6 +72,8 @@ export default Mixin.create({
       const root = document.documentElement;
       root.style.setProperty('--mainLeftOffset', `${this.mainLeftOffset}px`);
       root.style.setProperty('--mainRightOffset', `${this.mainRightOffset}px`);
+
+      this.handleFullSidebar();
     });
     this.appEvents.on('sidebar:toggle', this, this.toggleSidebars);
     
@@ -160,6 +162,17 @@ export default Mixin.create({
     }
   },
 
+  handleFullSidebar() {
+    if ($('aside.sidebar.left').hasClass('full')) {
+      $('#main-outlet').addClass('push-right');
+      $('.desktop-view').css('overflow-x', "hidden");
+
+    }
+    if ($('aside.sidebar.right').hasClass('full')) {
+      $('#main-outlet').addClass('push-left');
+    }
+  },
+
   @discourseComputed('responsiveView')
   isResponsive(responsiveView) {
     const mobileView = this.get('site.mobileView');
@@ -231,7 +244,9 @@ export default Mixin.create({
     if (hasRightSidebar) {
       offset += mainRightOffset;
     }
-    style += `width: ${offset > 0 ? `calc(100% - ${offset}px)` : '100%'}`;
+    if (!$('aside.sidebar').hasClass('full')) {
+      style += `width: ${offset > 0 ? `calc(100% - ${offset}px)` : '100%'}`;
+    }
     return htmlSafe(style);
   },
 

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -238,6 +238,9 @@ export default Mixin.create({
     if (this.site.mobileView) return;
     const mainLeftOffset = this.mainLeftOffset;
     const mainRightOffset = this.mainRightOffset;
+    const sidebarLeftPosition = this.siteSettings.layouts_sidebar_left_position;
+    const root = document.documentElement;
+     
     let offset = 0;
     let style = '';
     if (hasLeftSidebar) {
@@ -246,9 +249,12 @@ export default Mixin.create({
     if (hasRightSidebar) {
       offset += mainRightOffset;
     }
-    if (!$('aside.sidebar').hasClass('full')) {
-      style += `width: ${offset > 0 ? `calc(100% - ${offset}px)` : '100%'}`;
+    if (hasLeftSidebar && sidebarLeftPosition === 'full') {
+      offset = 0;
+      root.style.setProperty('overflow-x', 'hidden');
     }
+    style += `width: ${offset > 0 ? `calc(100% - ${offset}px)` : '100%'}`;
+
     return htmlSafe(style);
   },
 

--- a/assets/stylesheets/common/layouts-topic.scss
+++ b/assets/stylesheets/common/layouts-topic.scss
@@ -1,7 +1,7 @@
 $body-extension: 150px;
 $timeline-buffer: 100px;
 
-.main-content.topic {  
+body:not(.left-full) .main-content.topic {  
   &.left-sidebar {
     .topic-body {
       width: calc(

--- a/assets/stylesheets/common/layouts-widgets.scss
+++ b/assets/stylesheets/common/layouts-widgets.scss
@@ -37,6 +37,20 @@ aside.sidebar {
       top: 70px;
     }
   }
+
+  &.full {
+    position: fixed;
+    left: 0;
+    top: 4em;
+    height: 100vh;
+
+    .widget-container {
+      height: 100vh;
+      background: var(--primary-very-low);
+      box-shadow: inset -16px 0px 14px rgba(0, 0, 0, 0.04);
+      border: none;
+    }
+  }
 }
 
 .toggle-sidebar {

--- a/assets/stylesheets/common/layouts-widgets.scss
+++ b/assets/stylesheets/common/layouts-widgets.scss
@@ -40,16 +40,33 @@ aside.sidebar {
 
   &.full {
     position: fixed;
-    left: 0;
-    top: 4em;
-    height: 100vh;
 
     .widget-container {
       height: 100vh;
       background: var(--primary-very-low);
-      box-shadow: inset -16px 0px 14px rgba(0, 0, 0, 0.04);
       border: none;
     }
+  }
+}
+
+.full-left {
+  top: 4em;
+  height: 100vh;
+  left: 0;
+  
+  .widget-container {
+    box-shadow: inset -16px 0px 14px rgba(0, 0, 0, 0.04);
+  }
+}
+
+.full-right {
+  position: fixed;
+  top: 4em;
+  height: 100vh;
+  right: 0;
+
+  .widget-container {
+    box-shadow: inset 16px 0px 14px rgba(0, 0, 0, 0.04);
   }
 }
 

--- a/assets/stylesheets/common/layouts-widgets.scss
+++ b/assets/stylesheets/common/layouts-widgets.scss
@@ -45,6 +45,9 @@ aside.sidebar {
     .widget-container {
       background: inherit;
       border: none;
+      &:not(:last-of-type) {
+        border-bottom: 2px solid var(--primary-low);
+      }
     }
   }
 }

--- a/assets/stylesheets/common/layouts-widgets.scss
+++ b/assets/stylesheets/common/layouts-widgets.scss
@@ -40,10 +40,10 @@ aside.sidebar {
 
   &.full {
     position: fixed;
-
+    height: 100vh;
+    background: var(--primary-very-low);
     .widget-container {
-      height: 100vh;
-      background: var(--primary-very-low);
+      background: inherit;
       border: none;
     }
   }
@@ -53,10 +53,7 @@ aside.sidebar {
   top: 4em;
   height: 100vh;
   left: 0;
-  
-  .widget-container {
-    box-shadow: inset -16px 0px 14px rgba(0, 0, 0, 0.04);
-  }
+  box-shadow: inset -16px 0px 14px rgba(0, 0, 0, 0.04);
 }
 
 .right.full {
@@ -64,10 +61,7 @@ aside.sidebar {
   top: 4em;
   height: 100vh;
   right: 0;
-
-  .widget-container {
-    box-shadow: inset 16px 0px 14px rgba(0, 0, 0, 0.04);
-  }
+  box-shadow: inset 16px 0px 14px rgba(0, 0, 0, 0.04);
 }
 
 .toggle-sidebar {

--- a/assets/stylesheets/common/layouts-widgets.scss
+++ b/assets/stylesheets/common/layouts-widgets.scss
@@ -49,7 +49,7 @@ aside.sidebar {
   }
 }
 
-.full-left {
+.left.full {
   top: 4em;
   height: 100vh;
   left: 0;
@@ -59,7 +59,7 @@ aside.sidebar {
   }
 }
 
-.full-right {
+.right.full {
   position: fixed;
   top: 4em;
   height: 100vh;

--- a/assets/stylesheets/common/layouts.scss
+++ b/assets/stylesheets/common/layouts.scss
@@ -12,14 +12,14 @@
   display: flex;
 }
 
-.push-right {
+.push-right #main-outlet {
   padding-left: var(--mainLeftOffset);
   padding-right: var(--mainRightOffset);
   margin: 0 auto;
   width: calc(95% - var(--mainRightOffset));
 }
 
-.push-left {
+.push-left #main-outlet {
   padding-left: 5%;
   padding-right: var(--mainRightOffset);
   margin: 0 auto;

--- a/assets/stylesheets/common/layouts.scss
+++ b/assets/stylesheets/common/layouts.scss
@@ -12,18 +12,26 @@
   display: flex;
 }
 
-.push-right #main-outlet {
-  padding-left: var(--mainLeftOffset);
-  padding-right: var(--mainRightOffset);
-  margin: 0 auto;
-  width: calc(95% - var(--mainRightOffset));
-}
+body.left-full {
+  .wrap {
+    max-width: unset;
+  }
 
-.push-left #main-outlet {
-  padding-left: 5%;
-  padding-right: var(--mainRightOffset);
-  margin: 0 auto;
-  width: calc(95% - var(--mainRightOffset));
+  .d-header .wrap {
+    padding: 0 20px;
+  }
+
+  #main-outlet {
+    padding-left: var(--mainLeftOffset);
+    width: 100%;
+    box-sizing: border-box;
+
+    > .container,
+    > .content-wrapper {
+      max-width: 1110px;
+      margin: 0 auto;
+    }
+  }
 }
 
 html.mobile-device {
@@ -32,7 +40,7 @@ html.mobile-device {
   }
 }
 
-.main-content {
+body:not(.left-full) .main-content {
   margin-bottom: 100px;
 
   .list-controls {

--- a/assets/stylesheets/common/layouts.scss
+++ b/assets/stylesheets/common/layouts.scss
@@ -12,6 +12,17 @@
   display: flex;
 }
 
+.push-right {
+  padding-left: var(--mainLeftOffset);
+  padding-right: var(--mainRightOffset);
+  margin: 0 auto;
+  width: calc(95% - var(--mainRightOffset));
+}
+
+.push-left {
+  padding-right: var(--mainRightOffset);
+}
+
 html.mobile-device {
   .content-wrapper {
     display: initial;
@@ -37,7 +48,6 @@ html.mobile-device {
     .topic-list .posters {
       min-width: initial;
     }
-    
     .container.list-container {
       width: 100%;
     }

--- a/assets/stylesheets/common/layouts.scss
+++ b/assets/stylesheets/common/layouts.scss
@@ -20,7 +20,10 @@
 }
 
 .push-left {
+  padding-left: 5%;
   padding-right: var(--mainRightOffset);
+  margin: 0 auto;
+  width: calc(95% - var(--mainRightOffset));
 }
 
 html.mobile-device {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@ plugins:
       - fixed
       - absolute
       - sticky
+      - full
   layouts_sidebar_right_position:
     client: true
     default: 'fixed'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,6 +25,7 @@ plugins:
       - fixed
       - absolute
       - sticky
+      - full
   layouts_sidebar_left_can_hide:
     client: true
     type: list

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,7 +25,6 @@ plugins:
       - fixed
       - absolute
       - sticky
-      - full
   layouts_sidebar_left_can_hide:
     client: true
     type: list


### PR DESCRIPTION
Added "Full" option for left and right sidebars to appear in full height.

Currently, left sidebar works.

@angusmcleod Do you know why when I check the conditional to see whether currently there is a left or right sidebar, it outputs it as both many times (see image below)? This is resulting in `push-right` and `push-left` being applied to the `#main-outlet` and breaking the design, despite there being a conditional that should prevent it.

```js
  handleFullSidebar() {
    if ($('aside.sidebar.left.full')) {
      $("#main-outlet").addClass("push-right");
      $('.desktop-view').css('overflow-x', "hidden");
      $('aside.sidebar.left').addClass('full-left');
    }    
    if ($('aside.sidebar.right.full')) {
      $("#main-outlet").addClass('push-left');
      $('aside.sidebar.right').addClass('full-right');
    }
  },

```
I've also tried using the variables `hasRightSidebar` and `hasLeftSidebar` but the same issue presents itself.

<img width="643" alt="Screen Shot 2021-07-23 at 2 54 17 PM" src="https://user-images.githubusercontent.com/30090424/126845434-9ec7c14f-81d4-4459-aefc-94555cc94362.png">
