### PR TITLE
FIX: Toggle button not appearing in some routes

### DIFF
--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -48,7 +48,8 @@ export default Mixin.create({
   canHide(context, side, mobileView) {
     return !mobileView &&
       this.siteSettings[`layouts_sidebar_${side}_can_hide`].split('|')
-        .map(normalizeContext);
+        .map(normalizeContext)
+        .includes(normalizeContext(context));
   },
   
   @discourseComputed('rightSidebarVisible')

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -48,8 +48,7 @@ export default Mixin.create({
   canHide(context, side, mobileView) {
     return !mobileView &&
       this.siteSettings[`layouts_sidebar_${side}_can_hide`].split('|')
-        .map(normalizeContext)
-        .indexOf(context) > -1;
+        .map(normalizeContext);
   },
   
   @discourseComputed('rightSidebarVisible')


### PR DESCRIPTION
Toggle to hide sidebar does not appear in some routes, such as `/tags`.

Traced the issue back to the `canHide(context, side, mobileView)` method in `mixins/sidebars.js.es6`.

It appears that after the map is done, `indexOf(context)` always returns `-1` resulting in the toggle not passing the condition in the template:
```hbs
{{#if canHideRightSidebar}}
...
{{/if}}
```

@angusmcleod I removed the `.indexOf(context) > -1` portion and it doesn't seem to have broken anything, but I was wondering if you could review this change to ensure it is okay.