### PR TITLE
FIX: Checkbox causing issues with search

### DIFF
--- a/assets/javascripts/discourse/lib/layouts.js.es6
+++ b/assets/javascripts/discourse/lib/layouts.js.es6
@@ -222,6 +222,11 @@ function setupContext(context, app) {
 
     if (controllerExists) {
       api.modifyClass(controllerClass, Sidebars);
+      
+      if (context.name === 'search') {
+        api.modifyClass(controllerClass, { skip_context: true, context: name });
+      }
+      
       api.modifyClass(controllerClass, { context: name });
     } else {
       console.log('Layouts context is missing a controller: ', name);

--- a/assets/javascripts/discourse/lib/layouts.js.es6
+++ b/assets/javascripts/discourse/lib/layouts.js.es6
@@ -221,13 +221,8 @@ function setupContext(context, app) {
     let controllerExists = api._resolveClass(controllerClass);
 
     if (controllerExists) {
-      api.modifyClass(controllerClass, Sidebars);
-      
-      if (context.name === 'search') {
-        api.modifyClass(controllerClass, { skip_context: true, context: name });
-      }
-      
-      api.modifyClass(controllerClass, { context: name });
+      api.modifyClass(controllerClass, Sidebars);      
+      api.modifyClass(controllerClass, { layouts_context: name });
     } else {
       console.log('Layouts context is missing a controller: ', name);
     }

--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -35,12 +35,12 @@ export default Mixin.create({
   widgetsSet: or('leftWidgetsSet', 'rightWidgetsSet'),
   leftFull: equal('siteSettings.layouts_sidebar_left_position', 'full'),
   
-  @discourseComputed('context', 'mobileView')
+  @discourseComputed('layouts_context', 'mobileView')
   canHideRightSidebar(context, mobileView) {
     return this.canHide(context, 'right', mobileView);
   },
   
-  @discourseComputed('context', 'mobileView')
+  @discourseComputed('layouts_context', 'mobileView')
   canHideLeftSidebar(context, mobileView) {
     return this.canHide(context, 'left', mobileView);
   },

--- a/assets/javascripts/discourse/templates/sidebar-wrapper.hbs
+++ b/assets/javascripts/discourse/templates/sidebar-wrapper.hbs
@@ -18,7 +18,7 @@
         sidebarMinimized=leftSidebarMinimized
         category=category
         filter=sidebarFilter
-        context=context}}
+        context=layouts_context}}
       
       {{plugin-outlet
         name="sidebar-left-bottom"
@@ -30,7 +30,7 @@
           tabletView=tabletView
           mobileView=mobileView
           sidebarMinimized=leftSidebarMinimized
-          context=context
+          context=layouts_context
           path=path)}}
     </aside>
   {{/if}}
@@ -59,7 +59,7 @@
         sidebarMinimized=rightSidebarMinimized
         category=category
         filter=sidebarFilter
-        context=context}}
+        context=layouts_context}}
       
       {{plugin-outlet
         name="sidebar-right-bottom"
@@ -71,7 +71,7 @@
           tabletView=tabletView
           mobileView=mobileView
           sidebarMinimized=rightSidebarMinimized
-          context=context
+          context=layouts_context
           path=path)}}
     </aside>
   {{/if}}


### PR DESCRIPTION
![Screen Shot 2022-03-16 at 9 58 04 AM](https://user-images.githubusercontent.com/30090424/158645554-fb2e5f33-fa01-4942-b54d-4175a254970d.png)

**Issue:**
Full Page Search generates a checkbox below the searchbox (which is by default checked triggering `skip_context` to be `false`). With `skip_context` marked as `false`, search results never appear correctly (unless that checkbox is unchecked).

**Potential Reason**
By default Discourse uses the context property in the `full-page-search` route only when searching from mobileView. (Not sure the purpose of this).

However, because the Layouts plugin is using that same property name (`context`), it is triggering some unwanted functionality.

**Current Fix Approach**:
The initial approach I took to resolve this was by passing `{ skip_context: true }` when setting up the contexts for the Layouts plugin if the context is the search page.

```js
    if (controllerExists) {
      api.modifyClass(controllerClass, Sidebars);
      
      if (context.name === 'search') {
        api.modifyClass(controllerClass, { skip_context: true, context: name });
      }
      
      api.modifyClass(controllerClass, { context: name });
    } else {
      console.log('Layouts context is missing a controller: ', name);
    }
```

This helps by keeping that checkbox as unchecked by default, allowing searches to work correctly. However, I think a better solution would be is if that checkbox is not generated at all.

**Thoughts**
I'm not sure if this is really the best approach. I think it may be better if we change the use of the property `context` altogether so that it is more specific only to the Layouts plugin. However, in my attempts to do so have been unsuccessful. I'm not sure where exactly we are specifying the name context to start.

@angusmcleod 
Do you know how we could best resolve this issue? Or any other potential approaches?
