### PR TITLE
Remove use of Ember string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/mixins/sidebars.js.es6
+++ b/assets/javascripts/discourse/mixins/sidebars.js.es6
@@ -478,7 +478,7 @@ export default Mixin.create({
           let iconUrl = new URL(icon);
           iconHtml = htmlSafe(`<img src=${iconUrl.href} class="image-icon">`);
         } catch (_) {
-          iconHtml = iconHTML(icon).htmlSafe();
+          iconHtml = htmlSafe(iconHTML(icon));
         }
 
         if (iconHtml && iconClass && action && actionParam) {


### PR DESCRIPTION
These have been deprecated for some time, and are no longer available in Discourse. We can use the imported version instead.
